### PR TITLE
Correction scatter Plot axes

### DIFF
--- a/core/fslibs/FarseerSeries.py
+++ b/core/fslibs/FarseerSeries.py
@@ -2184,6 +2184,7 @@ variable or confirm you have not forgot any peaklist [{}].".\
             axs[i].set_xlim(-1,1)
             axs[i].set_ylim(-1,1)
             set_tick_labels()
+            axs[i].invert_yaxis()
             return
         
         elif not(self.ix[:,i,'H1_delta'].any()) \
@@ -2200,6 +2201,7 @@ variable or confirm you have not forgot any peaklist [{}].".\
             axs[i].set_xlim(-1,1)
             axs[i].set_ylim(-1,1)
             set_tick_labels()
+            axs[i].invert_yaxis()
             return
         
         # Plots data

--- a/core/fslibs/FarseerSeries.py
+++ b/core/fslibs/FarseerSeries.py
@@ -2184,6 +2184,7 @@ variable or confirm you have not forgot any peaklist [{}].".\
             axs[i].set_xlim(-1,1)
             axs[i].set_ylim(-1,1)
             set_tick_labels()
+            axs[i].invert_xaxis()
             axs[i].invert_yaxis()
             return
         
@@ -2201,6 +2202,7 @@ variable or confirm you have not forgot any peaklist [{}].".\
             axs[i].set_xlim(-1,1)
             axs[i].set_ylim(-1,1)
             set_tick_labels()
+            axs[i].invert_xaxis()
             axs[i].invert_yaxis()
             return
         


### PR DESCRIPTION
X and Y axes for Plot Scatter were not inverted for representation of `unassigned` and `all data lost` subplots. Now it represents correctly.