### PR TITLE
Sidechain parser improvement

### DIFF
--- a/core/fslibs/FarseerCube.py
+++ b/core/fslibs/FarseerCube.py
@@ -858,8 +858,8 @@ more details."
         # reverts previous merge
         if resonance_type=='Sidechains':
             target_pkl.loc[:,'ATOM'] = ref_pkl.loc[:,'ATOM']
-            target_pkl.loc[:,'ResNo'] = ref_pkl.loc[:,'ResNo'].str[:-1]
-            ref_pkl.loc[:,'ResNo'] = ref_pkl.loc[:,'ResNo'].str[:-1]
+            target_pkl.loc[:,'ResNo'] = ref_pkl.loc[:,'ResNo'].str.extract('(\d+)', expand=False)
+            ref_pkl.loc[:,'ResNo'] = ref_pkl.loc[:,'ResNo'].str.extract('(\d+)', expand=False)
         
         return \
             target_pkl, \

--- a/core/fslibs/FarseerCube.py
+++ b/core/fslibs/FarseerCube.py
@@ -629,8 +629,7 @@ If you choose continue, Farseer-NMR will parse out the digits.'.\
                 # DataFrame with side chains
                 self.allsidechains[z][y][x] = \
                     self.allpeaklists[z][y][x].loc[sidechains_bool,:]
-                # adds 'a' or 'b'
-                print(self.allsidechains[z][y][x].loc[:,'Assign F1'].str.split('[HN]', expand=True))
+                # adds sidechain nomenclature
                 self.allsidechains[z][y][x].loc[:,'ATOM'] = \
                     self.allsidechains[z][y][x].loc[:,'Assign F1'].\
                         str.split('[HN]', expand=True).loc[:,1]

--- a/core/fslibs/FarseerCube.py
+++ b/core/fslibs/FarseerCube.py
@@ -616,7 +616,7 @@ If you choose continue, Farseer-NMR will parse out the digits.'.\
             # identify the sidechain rows
             sidechains_bool = \
                 self.allpeaklists[z][y][x].\
-                    loc[:,'Assign F1'].str.contains('[ab]$')
+                    loc[:,'Assign F1'].str.contains('[^HN]$')
             # initiates SD counter
             sd_count = {True:0}
             
@@ -630,8 +630,10 @@ If you choose continue, Farseer-NMR will parse out the digits.'.\
                 self.allsidechains[z][y][x] = \
                     self.allpeaklists[z][y][x].loc[sidechains_bool,:]
                 # adds 'a' or 'b'
+                print(self.allsidechains[z][y][x].loc[:,'Assign F1'].str.split('[HN]', expand=True))
                 self.allsidechains[z][y][x].loc[:,'ATOM'] = \
-                    self.allsidechains[z][y][x].loc[:,'Assign F1'].str[-1]
+                    self.allsidechains[z][y][x].loc[:,'Assign F1'].\
+                        str.split('[HN]', expand=True).loc[:,1]
                 # resets index
                 self.allsidechains[z][y][x].reset_index(inplace=True)
                 # ResNo column to int preparing for reindex

--- a/core/fslibs/FarseerSeries.py
+++ b/core/fslibs/FarseerSeries.py
@@ -780,10 +780,20 @@ with window size {} and stdev {}'.\
             data_table = self.loc[:,:,tablecol]
             is_float = False
             
-        table = pd.concat([self.res_info.iloc[0,:,0:3], data_table], axis=1)
+        if resonance_type == 'Backbone':
+            table = pd.concat([self.res_info.iloc[0,:,0:3], data_table], axis=1)
         
         if resonance_type == 'Sidechains':
-            table.loc[:,'ResNo'] = table.loc[:,'ResNo'] + self.ix[0,:,'ATOM']
+            #table.loc[:,'ResNo'] = table.loc[:,'ResNo'] + self.ix[0,:,'ATOM']
+            table = pd.concat(
+                [
+                    self.res_info.iloc[0,:,0],
+                    self.ix[0,:,'ATOM'],
+                    self.res_info.iloc[0,:,1:3],
+                    data_table
+                    ],
+                axis=1
+                )
         
         tablefolder = '{}/{}'.format(
             self.tables_and_plots_folder, 

--- a/core/fslibs/FarseerSeries.py
+++ b/core/fslibs/FarseerSeries.py
@@ -1345,9 +1345,8 @@ recipient: residues
             # Configure XX ticks and Label
             axs[i].set_xticks(self.major_axis)
             ## https://github.com/matplotlib/matplotlib/issues/6266
-            print(self.loc[experiment,:,'ResNo'])
             axs[i].set_xticklabels(
-                self.loc[experiment,:,['ResNo','1-letter', 'ATOM']].\
+                self.loc[experiment,:,['ResNo', 'ATOM','1-letter']].\
                     apply(lambda x: ''.join(x), axis=1),
                 fontname=x_ticks_fn,
                 fontsize=x_ticks_fs,

--- a/core/fslibs/FarseerSeries.py
+++ b/core/fslibs/FarseerSeries.py
@@ -784,7 +784,6 @@ with window size {} and stdev {}'.\
             table = pd.concat([self.res_info.iloc[0,:,0:3], data_table], axis=1)
         
         if resonance_type == 'Sidechains':
-            #table.loc[:,'ResNo'] = table.loc[:,'ResNo'] + self.ix[0,:,'ATOM']
             table = pd.concat(
                 [
                     self.res_info.iloc[0,:,0],
@@ -1356,7 +1355,7 @@ recipient: residues
             axs[i].set_xticks(self.major_axis)
             ## https://github.com/matplotlib/matplotlib/issues/6266
             axs[i].set_xticklabels(
-                self.loc[experiment,:,['ResNo', 'ATOM','1-letter']].\
+                self.loc[experiment,:,['ResNo', '1-letter', 'ATOM']].\
                     apply(lambda x: ''.join(x), axis=1),
                 fontname=x_ticks_fn,
                 fontsize=x_ticks_fs,


### PR DESCRIPTION
**Issue:**

- User data contains additional formats for sidechain nomenclature.
- Some sidechains were not parsed 

**Solution:**

- Every row which Assign information contains any value different from H or N is considered sidechain (traetment of backbone carbon atoms is not yet implemented)
- improvements in table, peaklist and plot representation of sidechain data.
