### PR TITLE
Correcting run scripts generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # GitHub .gitignore boilerplate from https://github.com/github/gitignore/blob/master/Python.gitignore
 
-# Added by @miguelarbesu to ignore the local ./run_farseer.sh 
-run_farseer.sh
+# Ignore the local run_farseer*.sh files
+run_farseer_gui.sh
+run_farseer_commandline.sh
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # GitHub .gitignore boilerplate from https://github.com/github/gitignore/blob/master/Python.gitignore
 
 # Ignore the local run_farseer*.sh files
-run_farseer_gui.sh
-run_farseer_commandline.sh
+run_farseer.sh
+exec_farseer_commandline.sh
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Linux_install_Miniconda.sh
+++ b/Linux_install_Miniconda.sh
@@ -107,8 +107,8 @@ else
 fi
 
 echo
-echo "*** Configuring run_farseer.sh file..."
-tee run_farseer.sh <<< \
+echo "*** Configuring run_farseer_gui.sh file..."
+tee run_farseer_gui.sh <<< \
 "#!/usr/bin/env bash
 
 export CONDA_ROOT=\"$(pwd)/miniconda3/envs/farseernmr\"
@@ -117,8 +117,22 @@ export PYTHONPATH=\${CONDA_ROOT}:\${FARSEER_ROOT}
 
 \$CONDA_ROOT/bin/python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer.sh
+chmod u+x run_farseer_gui.sh
 echo "*** Done..."
+
+echo "*** Configuring run_farseer_commandline.sh file..."
+tee run_farseer_commandline.sh <<< \
+"#!/usr/bin/env bash
+
+export CONDA_ROOT=\"$(pwd)/miniconda3/envs/farseernmr\"
+export FARSEER_ROOT=\"$(pwd)\"
+export PYTHONPATH=\${CONDA_ROOT}:\${FARSEER_ROOT}
+
+\$CONDA_ROOT/bin/python \$FARSEER_ROOT/core/farseermain.py \$*
+"
+chmod u+x run_farseer_commandline.sh
+echo "*** Done..."
+
 echo "*** Cleaning..."
 # cleaning
 rm $minicondaversion
@@ -126,15 +140,11 @@ rm $minicondaversion
 echo \
 "   *****
     
-    Farseer-NMR as been correctly configured
+    Farseer-NMR run files have been correctly configured
     
-    TO LAUNCH FARSEER-NMR:
+    TO LAUNCH FARSEER-NMR GUI:
     
-    ./run_farseer.sh
+    ./run_farseer_gui.sh
     
-    or
-    
-    double click on the run_farseer.sh file
-    
-    :-)
+    or double click on the file :-)
 "

--- a/Linux_install_Miniconda.sh
+++ b/Linux_install_Miniconda.sh
@@ -107,8 +107,8 @@ else
 fi
 
 echo
-echo "*** Configuring run_farseer_gui.sh file..."
-tee run_farseer_gui.sh <<< \
+echo "*** Configuring run_farseer.sh file..."
+tee run_farseer.sh <<< \
 "#!/usr/bin/env bash
 
 export CONDA_ROOT=\"$(pwd)/miniconda3/envs/farseernmr\"
@@ -117,11 +117,11 @@ export PYTHONPATH=\${CONDA_ROOT}:\${FARSEER_ROOT}
 
 \$CONDA_ROOT/bin/python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer_gui.sh
+chmod u+x run_farseer.sh
 echo "*** Done..."
 
-echo "*** Configuring run_farseer_commandline.sh file..."
-tee run_farseer_commandline.sh <<< \
+echo "*** Configuring exec_farseer_commandline.sh file..."
+tee exec_farseer_commandline.sh <<< \
 "#!/usr/bin/env bash
 
 export CONDA_ROOT=\"$(pwd)/miniconda3/envs/farseernmr\"
@@ -130,7 +130,7 @@ export PYTHONPATH=\${CONDA_ROOT}:\${FARSEER_ROOT}
 
 \$CONDA_ROOT/bin/python \$FARSEER_ROOT/core/farseermain.py \$*
 "
-chmod u+x run_farseer_commandline.sh
+chmod u+x exec_farseer_commandline.sh
 echo "*** Done..."
 
 echo "*** Cleaning..."
@@ -144,7 +144,7 @@ echo \
     
     TO LAUNCH FARSEER-NMR GUI:
     
-    ./run_farseer_gui.sh
+    ./run_farseer.sh
     
     or double click on the file :-)
 "

--- a/Linux_install_env.sh
+++ b/Linux_install_env.sh
@@ -70,9 +70,9 @@ echo "*** Done..."
 
 echo
 echo
-echo "*** Configuring run_farseer_gui.sh file..."
+echo "*** Configuring run_farseer.sh file..."
 echo
-tee run_farseer_gui.sh <<< \
+tee run_farseer.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -82,12 +82,12 @@ source activate farseernmr
 
 python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer_gui.sh
+chmod u+x run_farseer.sh
 
 echo
-echo "*** Configuring run_farseer_commandline.sh file..."
+echo "*** Configuring exec_farseer_commandline.sh file..."
 echo
-tee run_farseer_commandline.sh <<< \
+tee exec_farseer_commandline.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -97,7 +97,7 @@ source activate farseernmr
 
 python \$FARSEER_ROOT/core/farseermain.py \$*
 "
-chmod u+x run_farseer_commandline.sh
+chmod u+x exec_farseer_commandline.sh
 
 echo "*** Done..."
 echo
@@ -107,7 +107,7 @@ echo \
     
     TO LAUNCH FARSEER-NMR GUI:
     
-    ./run_farseer_gui.sh
+    ./run_farseer.sh
     
     or double click on the file :-)
 "

--- a/Linux_install_env.sh
+++ b/Linux_install_env.sh
@@ -69,8 +69,10 @@ fi
 echo "*** Done..."
 
 echo
-echo "*** Configuring run_farseer.sh file..."
-tee run_farseer.sh <<< \
+echo
+echo "*** Configuring run_farseer_gui.sh file..."
+echo
+tee run_farseer_gui.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -80,21 +82,32 @@ source activate farseernmr
 
 python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer.sh
+chmod u+x run_farseer_gui.sh
+
+echo
+echo "*** Configuring run_farseer_commandline.sh file..."
+echo
+tee run_farseer_commandline.sh <<< \
+"#!/usr/bin/env bash
+
+export FARSEER_ROOT=\"$(pwd)\"
+export PYTHONPATH=\$PYTHONPATH:\${FARSEER_ROOT}
+
+source activate farseernmr
+
+python \$FARSEER_ROOT/core/farseermain.py \$*
+"
+chmod u+x run_farseer_commandline.sh
+
 echo "*** Done..."
 echo
 echo \
-"   *****
+"
+    Farseer-NMR run files have been correctly configured
     
-    Farseer-NMR as been correctly configured and
+    TO LAUNCH FARSEER-NMR GUI:
     
-    TO LAUNCH FARSEER-NMR:
+    ./run_farseer_gui.sh
     
-    ./run_farseer.sh
-    
-    or
-    
-    double click on the run_farseer.sh file
-    
-    :-)
+    or double click on the file :-)
 "

--- a/Linux_install_manual.sh
+++ b/Linux_install_manual.sh
@@ -3,7 +3,7 @@
 echo
 echo "*** Configuring run_farseer_gui.sh file..."
 echo
-tee run_farseer_gui.sh <<< \
+tee run_farseer.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -11,12 +11,12 @@ export PYTHONPATH=\$PYTHONPATH:\${FARSEER_ROOT}
 
 python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer_gui.sh
+chmod u+x run_farseer.sh
 
 echo
-echo "*** Configuring run_farseer_commandline.sh file..."
+echo "*** Configuring exec_farseer_commandline.sh file..."
 echo
-tee run_farseer_commandline.sh <<< \
+tee exec_farseer_commandline.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -24,7 +24,7 @@ export PYTHONPATH=\$PYTHONPATH:\${FARSEER_ROOT}
 
 python \$FARSEER_ROOT/core/farseermain.py \$*
 "
-chmod u+x run_farseer_commandline.sh
+chmod u+x exec_farseer_commandline.sh
 
 echo "*** Done..."
 echo
@@ -36,7 +36,7 @@ echo \
     
     TO RUN FARSEER-NMR GUI:
     
-    ./run_farseer_gui.sh
+    ./run_farseer.sh
     
     or double click on the file :-)
 "

--- a/Linux_install_manual.sh
+++ b/Linux_install_manual.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 echo
-echo "*** Configuring run_farseer.sh file..."
+echo "*** Configuring run_farseer_gui.sh file..."
 echo
-tee run_farseer.sh <<< \
+tee run_farseer_gui.sh <<< \
 "#!/usr/bin/env bash
 
 export FARSEER_ROOT=\"$(pwd)\"
@@ -11,22 +11,32 @@ export PYTHONPATH=\$PYTHONPATH:\${FARSEER_ROOT}
 
 python \$FARSEER_ROOT/gui/main.py \$*
 "
-chmod u+x run_farseer.sh
+chmod u+x run_farseer_gui.sh
+
+echo
+echo "*** Configuring run_farseer_commandline.sh file..."
+echo
+tee run_farseer_commandline.sh <<< \
+"#!/usr/bin/env bash
+
+export FARSEER_ROOT=\"$(pwd)\"
+export PYTHONPATH=\$PYTHONPATH:\${FARSEER_ROOT}
+
+python \$FARSEER_ROOT/core/farseermain.py \$*
+"
+chmod u+x run_farseer_commandline.sh
+
 echo "*** Done..."
 echo
 echo \
 "
-    run_farseer.sh has been created.
+    run_farseer_gui.sh and run_farseer_commandline.sh have been created.
     you may wish to complete this file with
     the necessary EXPORTS according to your Python setup.
     
-    TO RUN FARSEER-NMR:
+    TO RUN FARSEER-NMR GUI:
     
-    ./run_farseer.sh
+    ./run_farseer_gui.sh
     
-    or
-    
-    double click on the run_farseer.sh file
-    
-    :-)
+    or double click on the file :-)
 "

--- a/Linux_install_manual.sh
+++ b/Linux_install_manual.sh
@@ -30,8 +30,9 @@ echo "*** Done..."
 echo
 echo \
 "
-    run_farseer_gui.sh and run_farseer_commandline.sh have been created.
-    you may wish to complete this file with
+    Farseer-NMR run files have been correctly configured.
+
+    You may wish to complete this file with
     the necessary EXPORTS according to your Python setup.
     
     TO RUN FARSEER-NMR GUI:

--- a/gui/Footer.py
+++ b/gui/Footer.py
@@ -102,7 +102,7 @@ class Footer(QWidget):
         #
         version = '<span style="color: #036D8F; font-size: 6pt; ' \
                   'font-weight: 400; margin-right: 29px; margin-top: 4px;"' \
-                  '>v.1.2.1&nbsp;&nbsp;&nbsp;&nbsp;</span>'
+                  '>v.1.2.2&nbsp;&nbsp;&nbsp;&nbsp;</span>'
         self.versionLabel = QLabel(version, self)
         self.versionLabel.setAlignment(QtCore.Qt.AlignRight)
         #


### PR DESCRIPTION
Running farseermain.py from terminal was broken because libs were imported considering the PYTHONPATH to the Farseer-NMR folder was configured in .bashrc, this was not the case because the run_farseer.sh script exports the PYTHONPATH on the fly, and there was only a run script for the GUI.

Improvement:
- two run scripts are generated, one for the GUI and another for the commandline version.
- updated .gitignore
- upgraded to version 1.2.2
